### PR TITLE
Tell Travis CI to use Ubuntu Bionic

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,6 +1,8 @@
 ---
 .gitlab-ci.yml:
   delete: true
+.travis.yml:
+  dist: 'bionic'
 appveyor.yml:
   delete: true
 Gemfile:
@@ -17,4 +19,4 @@ Rakefile:
 spec/spec_helper.rb:
   mock_with: ':rspec'
   coverage_report: true
-  
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 ---
 os: linux
-dist: xenial
+dist: bionic
 language: ruby
 cache: bundler
 before_install:


### PR DESCRIPTION
When using the default of Ubuntu Xenial (16.04) the spec were failing
for some unknown reason. Switching to either Trusty or Bionic fixed the
tests. Seeing as Trusty is EoL I figured it makes sense to go ahead and
pin to Bionic.